### PR TITLE
Fix gpg2 homedir lookup

### DIFF
--- a/bin/sshcontrol
+++ b/bin/sshcontrol
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-declare -r GPGHOME="$(gpgconf --list-dirs homedir)"
+declare -r GPGHOME="$(gpgconf --list-dirs | grep -F 'homedir:' | cut -d ':' -f 2)"
 declare -r SSHCONTROL_FILE="${GPGHOME}/sshcontrol"
 
 usage() {


### PR DESCRIPTION
Seems some newer versions don't honor the "homedir" output only. GnuPG
2.0.30 outputs all directories.

@terlar you may be effected by this a well!